### PR TITLE
Add paragraph field to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -3,6 +3,7 @@ version=0.2.0
 author=Callum Bryant <callum.l.bryant@gmail.com>
 maintainer=Callum Bryant <callum.l.bryant@gmail.com>
 sentence=A library that makes creating sensor/actor nodes for the iotHub platform easy and fast
+paragraph=Should support up to 20 sensors per device.
 category=Communication
 url=https://github.com/Nixes/iotHubLib
 architectures=*


### PR DESCRIPTION
When the paragraph field is missing from library.properties, the Arduino IDE does not recognize the library:

- Sketch > Include Library > Add .ZIP Library fails silently.
- Compilation of any code that includes the library fails.
- After manual installation, "Invalid library" warnings are shown every time the libraries are scanned.
- Library Manager index inclusion request is blocked.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format